### PR TITLE
Fix PKCS#11 engine loading and host certificate profiles

### DIFF
--- a/src/config/create/default_openssl_config.ini
+++ b/src/config/create/default_openssl_config.ini
@@ -278,6 +278,10 @@ host_csr_file               = ${host_filename_prefix}csr.pem
 host_csr_ini_file           = ${host_filename_prefix}csr.ini
 #
 host_crt_ini_file           = ${host_filename_prefix}crt.ini
+# the host full dns name
+host_dns_name               = ${host}.${full_domain}
+#
+host_local_dns_name         = ${host}.${local_domain}
 ################################################
 # user related folders and files locations
 #
@@ -747,8 +751,7 @@ subjectKeyIdentifier        = hash
 crlDistributionPoints       = @subca_crl_uris
 # extendedKeyUsage            = clientAuth, emailProtection
 extendedKeyUsage            = serverAuth, clientAuth
-# nameConstraints disabled - OpenWrt strongswan does not support all constraint types
-#nameConstraints             = @subca_nc
+nameConstraints             = @subca_nc
 authorityInfoAccess         = @ca_issuer_info
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
@@ -771,8 +774,7 @@ authorityKeyIdentifier      = keyid:always, issuer:always
 crlDistributionPoints       = @subca_crl_uris
 # extendedKeyUsage            = clientAuth, emailProtection
 extendedKeyUsage            = serverAuth, clientAuth
-# nameConstraints disabled - OpenWrt strongswan does not support all constraint types
-#nameConstraints             = @subca_nc
+nameConstraints             = @subca_nc
 authorityInfoAccess         = @ca_issuer_info
 #issuerAltName               = issuer:copy
 ##############################################################################
@@ -790,12 +792,7 @@ extendedKeyUsage            = serverAuth
 # nameConstraints removed - RFC 5280 §4.2.1.10: must only appear in CA certs
 #nameConstraints             = critical, @host_nc
 authorityInfoAccess         = @subca_issuer_info
-# This stuff is for subjectAltName and issuerAltname.
-# Import the email address.
-#subjectAltName=email:copy
-# An alternative to produce certificates that aren''t
-# deprecated according to PKIX.
-subjectAltName              = email:move
+subjectAltName              = @host_alt_names
 #issuerAltName               = issuer:copy
 ###############################################
 # extensions for subca when signing host certs as well as for users when
@@ -813,6 +810,7 @@ extendedKeyUsage            = serverAuth
 # nameConstraints removed - RFC 5280 §4.2.1.10: must only appear in CA certs
 #nameConstraints             = critical, @host_nc
 authorityInfoAccess         = @subca_issuer_info
+subjectAltName              = @host_alt_names
 #issuerAltName               = issuer:copy
 ##############################################################################
 # extensions for subca when signing service certs as well as for users when
@@ -1221,9 +1219,11 @@ emailAddress                    = ${user}@${full_domain}
 #DNS.2 = ${name}.biz
 [ host_alt_names ]
 #
-#DNS.1 = ${name}.org
+email.0 = ${host}@${full_domain}
 #
-#DNS.2 = ${name}.biz
+DNS.1 = ${host_local_dns_name}
+#
+DNS.2 = ${host_dns_name}
 [ service_alt_names ]
 #
 DNS.1 = ${service_local_dns_name}

--- a/src/config/create/pkcs11_openssl_config.ini
+++ b/src/config/create/pkcs11_openssl_config.ini
@@ -1,4 +1,9 @@
-engines                     = engine_section
+# Engine auto-loading is intentionally disabled here to work around an
+# OpenSSL 3.0.x regression (ubuntu 3.0.2-0ubuntu1.21+) where eagerly-loaded
+# engines interfere with EVP signing ("command not supported" in
+# ctrl_params_translate.c). The PKCS#11 engine is instead loaded on demand
+# via the -engine pkcs11 flag, with PKCS11_MODULE_PATH set in the environment.
+#engines                     = engine_section
 ####################################################################
 #
 [ engine_section ]

--- a/src/create/crt/create_crt.sh
+++ b/src/create/crt/create_crt.sh
@@ -101,6 +101,10 @@ create_crt() {
       local pin_uri_fragment=""
       [ -n "$entity_pin" ] && pin_uri_fragment=";pin-value=${entity_pin}"
       local pkcs11_keyfile="pkcs11:id=%${sign_by_entity_pkcs11_id};type=private${pin_uri_fragment}"
+      # Set PKCS11_MODULE_PATH so the engine can find the PKCS#11 module
+      # when loaded on demand via -engine pkcs11 (engine is no longer
+      # auto-loaded from the OpenSSL config to avoid an EVP regression).
+      export PKCS11_MODULE_PATH="${opensc_pkcs11_module}"
       warn_yubikey_touch_expected $sign_by_entity
       openssl_command="$redirect_err openssl ca \
         -name $sign_by_entity \


### PR DESCRIPTION
## Summary
- Work around OpenSSL 3.0.x regression by disabling engine auto-loading; PKCS#11 engine is loaded on demand via `-engine pkcs11` flag instead
- Set `PKCS11_MODULE_PATH` in `create_crt.sh` so the engine finds the module at runtime
- Re-enable `nameConstraints` in SubCA certificate profiles
- Add `host_dns_name`/`host_local_dns_name` variables and populate `host_alt_names` SAN section with DNS names and email for host certificates

## Test plan
- [ ] Verify `sca create crt` works with YubiKey signing (PKCS#11 engine loads on demand)
- [ ] Verify host certificates include correct SAN entries
- [ ] Verify SubCA certificates include nameConstraints extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)