### PR TITLE
Add certificate revocation and CRL support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build/help/help.txt: build/common/help/help.txt src/help/command_title.txt \
 #------------------------------------------------------------------------------
 # CREATE command and subcommands
 #------------------------------------------------------------------------------
-CREATE_SUBCMDS := key csr crt pub pub_ssh crt_pub_ssh
+CREATE_SUBCMDS := key csr crt crl pub pub_ssh crt_pub_ssh
 
 $(eval $(call build_help,create,))
 $(foreach s,$(CREATE_SUBCMDS),$(eval $(call build_help,create,$(s))))
@@ -162,6 +162,17 @@ build/approve/approve.sh: src/approve/approve.sh build/approve/help/help.txt
 approve: build/approve/approve.sh
 
 #------------------------------------------------------------------------------
+# REVOKE command (no subcommands)
+#------------------------------------------------------------------------------
+$(eval $(call build_help,revoke,))
+
+build/revoke/revoke.sh: src/revoke/revoke.sh build/revoke/help/help.txt
+	@mkdir -p build/revoke
+	sed -e '/@@@HELP@@@/{r build/revoke/help/help.txt' -e 'd}' $< > $@
+
+revoke: build/revoke/revoke.sh
+
+#------------------------------------------------------------------------------
 # CONFIG command and subcommands
 #------------------------------------------------------------------------------
 # config_create has extra placeholders, so it gets a custom build rule below
@@ -239,7 +250,8 @@ install: build/install/install.sh
 #------------------------------------------------------------------------------
 # COMPLETION command
 #------------------------------------------------------------------------------
-COMPLETION_SCRIPTS := src/approve/complete_bash.sh src/completion/complete_bash.sh \
+COMPLETION_SCRIPTS := src/approve/complete_bash.sh src/revoke/complete_bash.sh \
+	src/completion/complete_bash.sh \
 	src/config/complete_bash.sh src/create/complete_bash.sh src/display/complete_bash.sh \
 	src/export/complete_bash.sh src/import/complete_bash.sh src/init/complete_bash.sh \
 	src/list/complete_bash.sh src/request/complete_bash.sh src/test/complete_bash.sh \
@@ -272,13 +284,14 @@ common: build/common/common.sh
 #------------------------------------------------------------------------------
 # Main SCA script
 #------------------------------------------------------------------------------
-COMMANDS := create display export import init request security_key approve config list test install completion common
+COMMANDS := create display export import init request security_key approve revoke config list test install completion common
 
 sca: src/sca.sh src/run.sh build/help/help.txt $(COMMANDS)
 	sed -e '/@@@HELP@@@/{r build/help/help.txt' -e 'd}' src/sca.sh > build/sca.sh
 	cat build/create/create.sh build/display/display.sh build/export/export.sh \
 		build/import/import.sh build/init/init.sh build/request/request.sh \
-		build/security_key/security_key.sh build/approve/approve.sh build/config/config.sh \
+		build/security_key/security_key.sh build/approve/approve.sh build/revoke/revoke.sh \
+		build/config/config.sh \
 		build/list/list.sh build/test/test.sh build/install/install.sh \
 		build/completion/completion.sh build/common/common.sh src/run.sh >> build/sca.sh
 	chmod 755 build/sca.sh

--- a/docker/crl-server/Dockerfile
+++ b/docker/crl-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+VOLUME /usr/share/nginx/html/crl
+
+EXPOSE 80

--- a/docker/crl-server/nginx.conf
+++ b/docker/crl-server/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html/crl;
+
+    location / {
+        autoindex on;
+        types {
+            application/x-pem-file pem;
+            application/pkix-crl crl;
+        }
+        default_type application/octet-stream;
+    }
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -57,6 +57,7 @@ sca create <document_type> <entity>
 | `crt` | Certificate |
 | `pub` | Public key (extracted from cert) |
 | `pub_ssh` | Public key in OpenSSH format |
+| `crl` | Certificate revocation list |
 | `crt_pub_ssh` | Batch: certificate + public keys |
 
 | Entity | Description |
@@ -81,7 +82,43 @@ sca create crt service
 
 # Batch create cert + public keys
 sca create crt_pub_ssh service
+
+# Generate CRL for sub-CA
+sca create crl subca
+
+# Generate CRL for root CA
+sca create crl ca
 ```
+
+---
+
+### revoke
+
+Revoke a certificate and regenerate the CRL.
+
+```bash
+sca revoke <entity>
+```
+
+| Option | Description |
+|--------|-------------|
+| `-h, --help` | Print help |
+| `-s, --sign-by` | Entity that signed the certificate (`ca` or `subca`) |
+
+**Examples:**
+
+```bash
+# Revoke a service certificate (signed by subca)
+sca revoke service
+
+# Revoke a sub-CA certificate (signed by ca)
+sca revoke subca
+
+# Revoke a host certificate specifying the signer
+sca revoke -s subca host
+```
+
+After revocation, the CRL is automatically regenerated. Distribute the updated CRL to relying parties.
 
 ---
 

--- a/docs/procedures.md
+++ b/docs/procedures.md
@@ -215,16 +215,20 @@ sca export crt_pub_ssh service
 ### Revoke and Update CRL
 
 ```bash
-# Revoke the certificate (requires root CA)
-openssl ca -revoke ~/.sca/keys/sb/harley/badservice/*-crt.pem \
-  -config ~/.sca/config/ca.ini
+# Configure the entity to revoke
+sca config set service badservice
 
-# Generate updated CRL
-openssl ca -gencrl -out ~/.sca/keys/sb/sb-crl.pem \
-  -config ~/.sca/config/ca.ini
+# Revoke the certificate (CRL is regenerated automatically)
+sca revoke service
+
+# If revoking a sub-CA certificate
+sca revoke subca
+
+# To regenerate CRL without revoking (e.g., after expiry update)
+sca create crl subca
 
 # Distribute CRL to services
-scp ~/.sca/keys/sb/sb-crl.pem root@router:/etc/ipsec.d/crls/
+scp ~/.sca/keys/<ca>/<subca>/<subca>-crl.pem root@router:/etc/ipsec.d/crls/
 ```
 
 ---

--- a/src/complete_bash.sh
+++ b/src/complete_bash.sh
@@ -114,7 +114,7 @@ _sca_complete() {
   fi
 
   if [ -z "${COMP_WORDS[${sca_verb_index}]}" ]; then
-    suggestions=($(compgen -W "create display export import init install list request security_key approve config completion test" -- "$current_word"))
+    suggestions=($(compgen -W "create display export import init install list request security_key approve revoke config completion test" -- "$current_word"))
   else
     case "${COMP_WORDS[${sca_verb_index}]}" in
       create)
@@ -147,6 +147,9 @@ _sca_complete() {
       approve)
         _sca_approve_complete ${sca_verb_index}
         ;;
+      revoke)
+        _sca_revoke_complete ${sca_verb_index}
+        ;;
       config)
         _sca_config_complete ${sca_verb_index}
         ;;
@@ -157,7 +160,7 @@ _sca_complete() {
         _sca_test_complete ${sca_verb_index}
         ;;
       *)
-        suggestions=($(compgen -W "create display export import init install list request security_key approve config completion test" -- "$current_word"))
+        suggestions=($(compgen -W "create display export import init install list request security_key approve revoke config completion test" -- "$current_word"))
         ;;
     esac
   fi

--- a/src/config/create/default_conventions.sh
+++ b/src/config/create/default_conventions.sh
@@ -273,17 +273,15 @@ export subca_crl_serial_file=${subca_filename_prefix}crl-srl.txt
 #
 export subca_crl_file=${subca_filename_prefix}crl.pem
 #
-export subca_crl_relative_file=${subca_filename_relative_prefix}crl-srl.txt
+export subca_crl_relative_file=${subca_filename_relative_prefix}crl.pem
 #
 export subca_yubikey_key_file=${subca_private_filename_prefix}yubikey-key.txt
 #
 export subca_yubikey_pin_file=${subca_private_filename_prefix}yubikey-pin.txt
 #
 export subca_yubikey_puk_file=${subca_private_filename_prefix}yubikey-puk.txt
-# TODO: fix below uri - use subca_crl_file below  !!!
 export subca_crl_uri=http://crl.${full_domain}/${subca_crl_relative_file}
-# TODO: fix below uri - use subca_crt_file below  !!!
-export subca_crt_uri=http://crl.${full_domain}/${subca}/${subca_crt_relative_file}
+export subca_crt_uri=http://crl.${full_domain}/${subca_crt_relative_file}
 #
 export subca_ocsp_uri=http://ocsp.${full_domain}/${subca}
 ################################################

--- a/src/create/complete_bash.sh
+++ b/src/create/complete_bash.sh
@@ -12,7 +12,7 @@ _sca_create_complete() {
   done
 
   if [ -z "${COMP_WORDS[$document_type_index]}" ]; then
-    suggestions=($(compgen -W "key csr crt pub pub_ssh crt_pub_ssh" -- "$current_word"))
+    suggestions=($(compgen -W "key csr crt crl pub pub_ssh crt_pub_ssh" -- "$current_word"))
   else
     case "${COMP_WORDS[$document_type_index]}" in
       key)
@@ -24,6 +24,9 @@ _sca_create_complete() {
       crt)
         _sca_create_crt_complete $document_type_index
         ;;
+      crl)
+        _sca_create_crl_complete $document_type_index
+        ;;
       pub)
         _sca_create_pub_complete $document_type_index
         ;;
@@ -34,7 +37,7 @@ _sca_create_complete() {
         _sca_create_crt_pub_ssh_complete $document_type_index
         ;;
       *)
-        suggestions=($(compgen -W "key csr crt pub pub_ssh crt_pub_ssh" -- "$current_word"))
+        suggestions=($(compgen -W "key csr crt crl pub pub_ssh crt_pub_ssh" -- "$current_word"))
         ;;
     esac
   fi
@@ -64,6 +67,32 @@ _sca_create_crt_complete() {
         ;;
       *)
         suggestions=($(compgen -W "ca subca host service user" -- "$current_word"))
+        ;;
+    esac
+  fi
+}
+_sca_create_crl_complete() {
+  local crl_index=$1
+  local entity_index=$((crl_index+1))
+
+  while [[ ${COMP_WORDS[$entity_index]} == -* ]]; do
+    if [ $COMP_CWORD == $entity_index ]; then
+      suggestions=($(compgen -W "-h --help" -- "$current_word"))
+      COMPREPLY=("${suggestions[@]}")
+      return
+    fi
+    entity_index=$((entity_index+1))
+  done
+
+  if [ -z "${COMP_WORDS[$entity_index]}" ]; then
+    suggestions=($(compgen -W "ca subca" -- "$current_word"))
+  else
+    case  "${COMP_WORDS[$entity_index]}" in
+      ca|subca)
+        :
+        ;;
+      *)
+        suggestions=($(compgen -W "ca subca" -- "$current_word"))
         ;;
     esac
   fi

--- a/src/create/create.sh
+++ b/src/create/create.sh
@@ -33,14 +33,14 @@ create() {
   local document_type=$1
   log_detailed "create: start (document_type=${document_type})"
   case "$document_type" in
-    key|csr|crt|pub|pub_ssh|crt_pub_ssh)
+    key|csr|crt|crl|pub|pub_ssh|crt_pub_ssh)
       shift
       eval create_$document_type "$@"
       ;;
     *)
       read -r -d '' message <<- ____EOM
         invalid value '$document_type' for document_type (first) argument.
-        supported values are 'key' 'csr' 'crt' 'pub' 'pub_ssh' 'crt_pub_ssh'.
+        supported values are 'key' 'csr' 'crt' 'crl' 'pub' 'pub_ssh' 'crt_pub_ssh'.
 ____EOM
       error "$message" 1
       ;;

--- a/src/create/crl/create_crl.sh
+++ b/src/create/crl/create_crl.sh
@@ -1,0 +1,107 @@
+################################################################################
+# generate certificate revocation list (CRL) for a certificate authority
+#
+# parameters
+#   entity
+#       the entity for which to generate the CRL
+#       allowed values are 'ca' and 'subca'
+#
+create_crl() {
+  local OPTS=`getopt -o h --long help -n 'create crl' -- "$@"`
+  if [ $? != 0 ] ; then
+    error "failed parsing options. use sca create crl -h for help." 1;
+  fi
+  eval set -- "$OPTS"
+  while true; do
+    case "$1" in
+      -h | --help )
+        create_crl_help
+        return
+      ;;
+      -- )
+        shift
+        break
+      ;;
+      * )
+        break
+      ;;
+    esac
+  done
+  local entity="$1"
+
+  log_detailed "create_crl: start (entity='${entity}')"
+
+  if [ "$entity" != "ca" ] && [ "$entity" != "subca" ]; then
+    error "create_crl: invalid entity '${entity}'. allowed values are 'ca' and 'subca'." 1
+  fi
+
+  export OPENSSL_CONF="${sca_conf_folder}${entity}.ini"
+  local entity_key_file=$(eval echo \$${entity}_key_file)
+  local entity_crl_file=$(eval echo \$${entity}_crl_file)
+  local entity_crl_serial_file=$(eval echo \$${entity}_crl_serial_file)
+  local openssl_command=""
+  local entity_pin=""
+
+  # initialize CRL serial if needed
+  if [ ! -f "$entity_crl_serial_file" ] || [ ! -s "$entity_crl_serial_file" ]; then
+    mkdir -p "$(dirname "$entity_crl_serial_file")"
+    echo "01" > "$entity_crl_serial_file"
+    log_detailed "create_crl: initialized CRL serial file $entity_crl_serial_file"
+  fi
+
+  # check if the entity_key_file exists in the filesystem
+  if [ -f "$entity_key_file" ]; then
+    # use filesystem key to generate CRL
+    openssl_command="$redirect_err openssl ca \
+      -name $entity \
+      -gencrl \
+      -out $entity_crl_file \
+      -keyfile $entity_key_file"
+  else
+    # check if the entity is configured to use a hardware security key
+    local entity_use_security_key=$(eval echo \$${entity}_use_security_key)
+    if [ $entity_use_security_key = true ]; then
+      local entity_security_key_type=$(eval echo \$${entity}_security_key_type)
+      local entity_pkcs11_id=$(eval echo \${${entity}_pkcs11_id})
+      local security_key_opensc_reader_slot_number=$(security_key_wait_for $entity)
+      readarray slot_map < <( p11tool --list-tokens | grep -oP "(?<=URL: ).*" )
+      log_detailed "create_crl: slot_map retrieved. there are ${#slot_map[@]} items."
+      log_detailed "create_crl: opensc reader slot number '${security_key_opensc_reader_slot_number}' mapped to pkcs11 id is '${slot_map[${security_key_opensc_reader_slot_number}]::-1}'."
+      local mapped_slot_id="${slot_map[${security_key_opensc_reader_slot_number}]::-1}"
+      local entity_pin=$(get_yubikey_pin_parameter $entity)
+      local pin_uri_fragment=""
+      [ -n "$entity_pin" ] && pin_uri_fragment=";pin-value=${entity_pin}"
+      local pkcs11_keyfile="pkcs11:id=%${entity_pkcs11_id};type=private${pin_uri_fragment}"
+      export PKCS11_MODULE_PATH="${opensc_pkcs11_module}"
+      warn_yubikey_touch_expected $entity
+      openssl_command="$redirect_err openssl ca \
+        -name $entity \
+        -gencrl \
+        -out $entity_crl_file \
+        -engine pkcs11 \
+        -keyform engine \
+        -keyfile \"${pkcs11_keyfile}\""
+    else
+      error "create_crl: Unable to find key file $entity_key_file for"\
+" $entity entity" 1
+    fi
+  fi
+
+  log_verbose "$openssl_command"
+  if [ -n "$entity_pin" ]; then
+    eval "$openssl_command" <<< "$entity_pin"
+  else
+    eval "$openssl_command"
+  fi
+  [ ! "$?" = "0" ] && error "create_crl: error while running the openssl command." 1
+
+  echo "CRL generated: $entity_crl_file"
+
+  log_detailed "create_crl: finish (entity='${entity}')"
+}
+
+create_crl_help() {
+  echo "
+@@@HELP@@@
+"
+}

--- a/src/create/crl/help/abstract.txt
+++ b/src/create/crl/help/abstract.txt
@@ -1,0 +1,1 @@
+Generate a certificate revocation list (CRL) for the specified entity.

--- a/src/create/crl/help/command_title.txt
+++ b/src/create/crl/help/command_title.txt
@@ -1,0 +1,1 @@
+The create crl command help

--- a/src/create/crl/help/further_read.txt
+++ b/src/create/crl/help/further_read.txt
@@ -1,0 +1,1 @@
+see also: sca revoke -h

--- a/src/create/crl/help/options.txt
+++ b/src/create/crl/help/options.txt
@@ -1,0 +1,3 @@
+crl_options:
+
+  -h, --help              - print this help

--- a/src/create/crl/help/syntax.txt
+++ b/src/create/crl/help/syntax.txt
@@ -1,0 +1,12 @@
+sca [<sca_options>] create [<create_options>] crl [<crl_options>] <entity>
+
+@@@SCA OPTIONS@@@
+
+@@@CREATE OPTIONS@@@
+
+@@@OPTIONS@@@
+
+allowed values for the entity are:
+
+  - ca            - for current certificate authority
+  - subca         - for current sub-ordinate certificate authority

--- a/src/create/help/syntax.txt
+++ b/src/create/help/syntax.txt
@@ -9,6 +9,7 @@ allowed values for the document_type are:
   - key                   - create new private key
   - csr                   - create certificate signature request
   - crt                   - create certificate
+  - crl                   - generate certificate revocation list
   - pub                   - create public key by extracting it from certificate
   - pub_ssh               - create public key in OpenSSH format
   - crt_pub_ssh           - batch creation of certificate, public key and public

--- a/src/help/syntax.txt
+++ b/src/help/syntax.txt
@@ -6,6 +6,7 @@ allowed values for the verb are:
 
   - request               - create request for a security document
   - approve               - approve request
+  - revoke                - revoke a certificate and regenerate CRL
   - create                - create security documents
   - display               - display security documents
   - export                - export security documents

--- a/src/revoke/complete_bash.sh
+++ b/src/revoke/complete_bash.sh
@@ -1,0 +1,65 @@
+_sca_revoke_complete() {
+  local revoke_index=$1
+  local entity_index=$((revoke_index+1))
+
+  # find the sca verb index on the command line by skipping over any options
+  # that are specified on the command line
+  while [[ ${COMP_WORDS[$entity_index]} == -* ]]; do
+    # ${COMP_WORDS[$sca_verb_index]} is an option
+
+    # in case the cursor is at the current $sca_verb_index word, return
+    # sca options as completion suggestions
+    if [ $COMP_CWORD == $entity_index ]; then
+      suggestions=($(compgen -W "-h --help -s --sign-by" -- "$current_word"))
+      COMPREPLY=("${suggestions[@]}")
+      return
+    fi
+
+    # the cursor is not on the current $sca_verb_index
+
+    # check if current option at $sca_verb_index is the sign-by option
+    if [ ${COMP_WORDS[$entity_index]} == --sign-by ] || [ ${COMP_WORDS[$entity_index]} == -s ]; then
+
+      # check if the cursor is now on the next option to process. in other words
+      # check if the following option at $entity_index+1 is the current word
+      if [  $((entity_index+1)) == $COMP_CWORD ]; then
+
+        # cursor is now on the next option to process, after the -s option. completing...
+
+        suggestions=($(compgen -W "ca subca" -- "$current_word"))
+        COMPREPLY=("${suggestions[@]}")
+        return
+      else
+
+        # following option at $sca_verb_index+1 is not the current word.
+
+        # check if the configuration file has been already specified after the
+        # current option at $sca_verb_index
+        if [ $((entity_index+1)) -lt ${#COMP_WORDS[@]} ]; then
+
+          # the configuration file has been already specified after the
+          # current option
+
+          sign_by_entity=${COMP_WORDS[$((entity_index+1))]}
+
+          entity_index=$((entity_index+1))
+        fi
+      fi
+    fi
+    entity_index=$((entity_index+1))
+  done
+
+
+  if [ -z "${COMP_WORDS[$entity_index]}" ]; then
+    suggestions=($(compgen -W "subca host service user" -- "$current_word"))
+  else
+      case "${COMP_WORDS[$entity_index]}" in
+        subca|host|service|user)
+          :
+          ;;
+        *)
+          suggestions=($(compgen -W "subca host service user" -- "$current_word"))
+          ;;
+      esac
+  fi
+}

--- a/src/revoke/help/abstract.txt
+++ b/src/revoke/help/abstract.txt
@@ -1,0 +1,1 @@
+Revoke a certificate and regenerate the certificate revocation list (CRL).

--- a/src/revoke/help/command_title.txt
+++ b/src/revoke/help/command_title.txt
@@ -1,0 +1,1 @@
+The revoke command help

--- a/src/revoke/help/further_read.txt
+++ b/src/revoke/help/further_read.txt
@@ -1,0 +1,1 @@
+see also: sca create crl -h

--- a/src/revoke/help/options.txt
+++ b/src/revoke/help/options.txt
@@ -1,0 +1,8 @@
+revoke_options:
+
+  -h, --help      - optional. if used the operation is completed by presenting
+                    this help.
+  -s, --sign-by   - optional. if used, specifies the entity whose key was used
+                    to sign the certificate being revoked. valid values are
+                    'ca' and 'subca'. defaults to 'subca', or 'ca' if the
+                    entity being revoked is 'subca'.

--- a/src/revoke/help/syntax.txt
+++ b/src/revoke/help/syntax.txt
@@ -1,0 +1,12 @@
+sca [<sca_options>] revoke [<revoke_options>] <entity>
+
+@@@SCA OPTIONS@@@
+
+@@@OPTIONS@@@
+
+allowed values for the entity are:
+
+  - subca         - for current sub-ordinate certificate authority
+  - user          - for current user
+  - host          - for current host
+  - service       - for current service

--- a/src/revoke/revoke.sh
+++ b/src/revoke/revoke.sh
@@ -1,0 +1,120 @@
+################################################################################
+# revoke a certificate and regenerate the CRL
+#
+# parameters
+#   entity
+#     the entity whose certificate to revoke
+#     allowed values are 'subca' 'host' 'service' 'user'
+#   sign_by_entity
+#     the entity that signed the certificate being revoked.
+#     optional. specified under option -s or --sign-by .
+#     if not set, default resolves to subca unless entity is 'subca'. in that
+#     case the default value for sign_by_entity parameter is 'ca'.
+#
+revoke() {
+
+  # read the options
+  local OPTS=`getopt -o hs: --long help,sign-by: -n 'revoke' -- "$@"`
+  local sign_by_entity
+  if [ $? != 0 ] ; then error "failed parsing options. use sca revoke -h for help." 1; fi
+  eval set -- "$OPTS"
+  while true; do
+    case "$1" in
+      -h | --help )
+        revoke_help
+        return
+        ;;
+      -s | --sign-by)
+        sign_by_entity=$2
+        shift;shift
+        ;;
+      -- )
+        shift
+        break
+        ;;
+      * )
+        break
+        ;;
+    esac
+  done
+
+  # read the parameters
+  local entity=$1
+
+  if [ -z "$entity" ]; then
+    error "revoke: entity argument is required. use sca revoke -h for help." 1
+  fi
+
+  if [ -z "$sign_by_entity" ]; then
+    [[ $entity == subca ]] && sign_by_entity=ca || sign_by_entity=subca
+  fi
+  log_detailed "revoke: start (entity=${entity}, sign_by_entity=${sign_by_entity})"
+
+  export OPENSSL_CONF="${sca_conf_folder}${sign_by_entity}.ini"
+  local sign_by_entity_key_file=$(eval echo \$${sign_by_entity}_key_file)
+  local entity_crt_file=$(eval echo \${${entity}_crt_file})
+  local openssl_command=""
+  local entity_pin=""
+
+  # verify certificate file exists
+  if [ ! -f "$entity_crt_file" ]; then
+    error "revoke: certificate file ($entity_crt_file) for entity "\
+"'$entity' not found." 1
+  fi
+
+  # check if the sign_by_entity_key_file exists in the filesystem
+  if [ -f "$sign_by_entity_key_file" ]; then
+    openssl_command="$redirect_err openssl ca \
+      -name $sign_by_entity \
+      -revoke $entity_crt_file \
+      -keyfile $sign_by_entity_key_file"
+  else
+    # check if the signing entity is configured to use a hardware security key
+    local sign_by_entity_use_security_key=$(eval echo \$${sign_by_entity}_use_security_key)
+    if [ $sign_by_entity_use_security_key = true ]; then
+      local sign_by_entity_security_key_type=$(eval echo \$${sign_by_entity}_security_key_type)
+      local sign_by_entity_pkcs11_id=$(eval echo \${${sign_by_entity}_pkcs11_id})
+      local security_key_opensc_reader_slot_number=$(security_key_wait_for $sign_by_entity)
+      readarray slot_map < <( p11tool --list-tokens | grep -oP "(?<=URL: ).*" )
+      log_detailed "revoke: slot_map retrieved. there are ${#slot_map[@]} items."
+      log_detailed "revoke: opensc reader slot number '${security_key_opensc_reader_slot_number}' mapped to pkcs11 id is '${slot_map[${security_key_opensc_reader_slot_number}]::-1}'."
+      local mapped_slot_id="${slot_map[${security_key_opensc_reader_slot_number}]::-1}"
+      local entity_pin=$(get_yubikey_pin_parameter $sign_by_entity)
+      local pin_uri_fragment=""
+      [ -n "$entity_pin" ] && pin_uri_fragment=";pin-value=${entity_pin}"
+      local pkcs11_keyfile="pkcs11:id=%${sign_by_entity_pkcs11_id};type=private${pin_uri_fragment}"
+      export PKCS11_MODULE_PATH="${opensc_pkcs11_module}"
+      warn_yubikey_touch_expected $sign_by_entity
+      openssl_command="$redirect_err openssl ca \
+        -name $sign_by_entity \
+        -revoke $entity_crt_file \
+        -engine pkcs11 \
+        -keyform engine \
+        -keyfile \"${pkcs11_keyfile}\""
+    else
+      error "revoke: Unable to find key file $sign_by_entity_key_file for"\
+" $sign_by_entity entity" 1
+    fi
+  fi
+
+  log_verbose "$openssl_command"
+  if [ -n "$entity_pin" ]; then
+    eval "$openssl_command" <<< "$entity_pin"
+  else
+    eval "$openssl_command"
+  fi
+  [ ! "$?" = "0" ] && error "revoke: error while running the openssl revoke command." 1
+
+  echo "Certificate revoked: $entity_crt_file"
+
+  # regenerate the CRL
+  echo "Regenerating CRL for $sign_by_entity..."
+  create_crl $sign_by_entity
+
+  log_detailed "revoke: finish (entity=${entity}, sign_by_entity=${sign_by_entity})"
+}
+revoke_help() {
+  echo "
+@@@HELP@@@
+  "
+}

--- a/src/sca.sh
+++ b/src/sca.sh
@@ -15,6 +15,7 @@
 #       - request
 #       - security_key
 #       - approve
+#       - revoke
 #       - config
 #       - list
 #       - completion
@@ -122,7 +123,7 @@ exiting.
   # eval set -- "$OPTS"
 
   case "$verb" in
-    create|display|export|import|init|request|security_key|approve|config|list|completion|install|test)
+    create|display|export|import|init|request|security_key|approve|revoke|config|list|completion|install|test)
       shift
       log_detailed "sca: calling function for the verb $verb "$@""
       if [ $verb == 'export' ]; then eval ${verb}_ "${@@Q}"; else eval $verb "${@@Q}"; fi
@@ -131,7 +132,7 @@ exiting.
       read -r -d '' message <<- ____EOM
         invalid value '$verb' for first argument - the command.
         supported commands are 'create' 'display' 'export' 'import' 'init' 'install'
-        'request' 'security_key' 'approve' 'completion' 'test'.
+        'request' 'security_key' 'approve' 'revoke' 'completion' 'test'.
 ____EOM
       error "$message" 1
       ;;


### PR DESCRIPTION
## Summary
- Add `sca revoke <entity>` command to revoke certificates and auto-regenerate the CRL
- Add `sca create crl <entity>` subcommand to generate CRLs for CA or SubCA
- Fix SubCA CRL/CRT URI paths in default conventions (`crl-srl.txt` → `crl.pem`, remove duplicate `${subca}/` prefix)
- Add nginx-based CRL distribution server (`docker/crl-server/`)
- Update docs and bash completion for new commands

Closes #24

## Test plan
- [x] `make clean && make` builds successfully
- [x] `sca revoke --help` and `sca create crl --help` render correctly
- [x] `sca --help` lists `revoke`, `sca create --help` lists `crl`
- [x] End-to-end test with isolated software-key PKI: `create crl subca` generates valid CRL, `revoke service` revokes cert and regenerates CRL with revoked serial
- [x] `create crl ca` works for root CA
- [ ] Tab completion for `sca revoke <TAB>` and `sca create crl <TAB>`
- [ ] `docker build -t sca-crl-server docker/crl-server/`
- [ ] Test with YubiKey-backed CA/SubCA

🤖 Generated with [Claude Code](https://claude.com/claude-code)