### PR TITLE
Add CI workflows for releases and skill sync

### DIFF
--- a/.github/workflows/notify-skill-update.yml
+++ b/.github/workflows/notify-skill-update.yml
@@ -1,0 +1,25 @@
+name: Notify skill update
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.claude/skills/sca-cskill/**'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch sync event to marketplace
+        env:
+          GH_TOKEN: ${{ secrets.SKILL_SYNC_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/harley-systems/claude-skills/dispatches \
+            -f "event_type=sync-skill" \
+            -f "client_payload[skill]=sca-cskill" \
+            -f "client_payload[source_repo]=harley-systems/sca" \
+            -f "client_payload[source_path]=.claude/skills/sca-cskill" \
+            -f "client_payload[source_sha]=${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+    branches: [main]
+    paths:
+      - 'docker/crl-server/**'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: [self-hosted, Linux, X64, home-network]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build SCA
+        run: make clean && make
+
+      - name: Generate bash completion
+        run: build/sca.sh completion bash > build/sca-completion.bash
+
+      - name: Generate checksums
+        working-directory: build
+        run: sha256sum sca.sh sca-completion.bash > SHA256SUMS
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            build/sca.sh#sca \
+            build/sca-completion.bash \
+            build/SHA256SUMS
+
+  build-container:
+    runs-on: [self-hosted, Linux, X64, home-network]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine tags
+        id: tags
+        run: |
+          IMAGE="ghcr.io/harley-systems/sca-crl-server"
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION="${{ github.ref_name }}"
+            echo "tags=${IMAGE}:${VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push container
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/crl-server
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ sudo systemctl enable --now pcscd
 
 ### Install SCA
 
+#### From release (recommended)
+
+```bash
+# Download latest release
+curl -L https://github.com/harley-systems/sca/releases/latest/download/sca -o ~/bin/sca
+chmod +x ~/bin/sca
+
+# Enable bash completion
+curl -L https://github.com/harley-systems/sca/releases/latest/download/sca-completion.bash \
+  -o ~/.local/share/bash-completion/completions/sca
+```
+
+#### From source
+
 ```bash
 # Build
 make

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,6 +6,20 @@ Complete reference for all SCA commands.
 
 ## Installation
 
+### From release
+
+```bash
+# Download latest release
+curl -L https://github.com/harley-systems/sca/releases/latest/download/sca -o ~/bin/sca
+chmod +x ~/bin/sca
+
+# Download bash completion
+curl -L https://github.com/harley-systems/sca/releases/latest/download/sca-completion.bash \
+  -o ~/.local/share/bash-completion/completions/sca
+```
+
+### From source
+
 ```bash
 # Build and install to ~/bin with bash completion
 make deploy


### PR DESCRIPTION
## Summary
- Add release workflow (`.github/workflows/release.yml`): builds sca, generates completion and checksums, creates GitHub release on `v*` tags. Also builds and pushes `sca-crl-server` container to GHCR on tags and Dockerfile changes on main.
- Add skill sync notification workflow (`.github/workflows/notify-skill-update.yml`): dispatches `sync-skill` event to `claude-skills` marketplace when `sca-cskill` changes on main.
- Add release-based install instructions to README and docs/commands.md.

## Secrets required
| Secret | Purpose |
|--------|---------|
| `SKILL_SYNC_TOKEN` | PAT to dispatch events to `claude-skills` repo |

Closes #12, closes #22

## Test plan
- [ ] Push a test tag `v0.1.0` — verify release workflow creates GitHub release with sca + completion + checksums
- [ ] Verify GHCR image after Dockerfile is added: `docker pull ghcr.io/harley-systems/sca-crl-server`
- [ ] Push a change to `.claude/skills/sca-cskill/` on main — verify dispatch triggers and `claude-skills` repo receives sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)